### PR TITLE
YAML Absolute path solution

### DIFF
--- a/src/word_detection.py
+++ b/src/word_detection.py
@@ -1,7 +1,7 @@
 from ultralytics import YOLO
 import torch
 import os
-
+import yaml
 
 if torch.cuda.is_available():
     dev = "cuda:0"
@@ -19,21 +19,51 @@ WORD_DETECT_BEST_MODEL = os.path.join("models", "word_detect_best.pt")
 LINES_OBB_BEST = os.path.join("models", "lines_obb_best.pt")
 
 
-def train_detection_model(model_path: str = YOLO_MOLDEL, 
-                          data_file: str = "words_data.yaml",
-                          epochs: int = 50) -> None:
+def fixup_yaml(yaml_path: str) -> None:
+    """Fix the absolute path to datasets in a yaml configuration"""
+    if not os.path.exists(yaml_path):
+        print(f"ERROR: Can not fixup'{yaml_path}', REASON: Does not exist")
+        return
+
+    with open(yaml_path, 'r') as file:
+        data = yaml.safe_load(file)
+
+    if "path" in data:
+        data["path"] = os.path.normpath(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), 
+                "../datasets", 
+                os.path.splitext(os.path.basename(yaml_path))[0]
+            )
+        )
+
+    with open(yaml_path, 'w') as file:
+        yaml.dump(data, file, indent=2)
+
+def train_detection_model(
+        model_path: str = YOLO_MOLDEL, 
+        data_file: str = f"{os.path.dirname(os.path.abspath(__file__))}/words_data.yaml",
+        epochs: int = 50
+    ) -> None:
     """Trains a model. The results of training will be stored at run/detect directory"""
 
+    fixup_yaml(data_file)
     model = YOLO(model_path).to(TORCH_DEVICE)
-    model.train(data=data_file, epochs=epochs, batch=1, imgsz=IMG_SIZE, device=YOLO_DEVICE, workers=1,
-                hsv_h=0.0, hsv_s=0.0, hsv_v=0.0, translate=0.1, scale=0.1, fliplr=0.0, mosaic=0.0, erasing=0.0,
-                crop_fraction=0.1)
+    model.train(
+        data=data_file, epochs=epochs, batch=1,
+        imgsz=IMG_SIZE, device=YOLO_DEVICE, workers=1,
+        hsv_h=0.0, hsv_s=0.0, hsv_v=0.0, translate=0.1,
+        scale=0.1, fliplr=0.0, mosaic=0.0, erasing=0.0,
+        crop_fraction=0.1
+    )
 
 
-def inference(images_dir: str,
-              model_path: str = WORD_DETECT_BEST_MODEL, 
-              min_confidence: float = 0.28,
-              show=False) -> None:
+def inference(
+        images_dir: str,
+        model_path: str = WORD_DETECT_BEST_MODEL, 
+        min_confidence: float = 0.28,
+        show=False
+    ) -> None:
     """Inferences a model. The results will be saved at prediction directory"""
     
     model = YOLO(model_path).to(TORCH_DEVICE)
@@ -53,17 +83,28 @@ def inference(images_dir: str,
 
 
 if __name__ == "__main__":
-    # Uncomment the line below to train to detect lines oriented bboxes
-    # train_detection_model(epochs=5, data_file="lines_obb_data.yaml", model_path="yolov8n-obb.pt")
+    # Uncomment the line below to train to detect lines oriented boxes
+    """
+    train_detection_model(
+        epochs=5,
+        data_file=f"{os.path.dirname(os.path.abspath(__file__))}/words_lines_data.yaml",
+        model_path="yolov8n-obb.pt"
+    )
+    """
 
-    
     # Uncomment the line below to train to detect words bboxes
-    # train_detection_model(epochs=5, data_file="words_data.yaml", model_path="yolov8n.pt")
-
+    """
+    train_detection_model(
+        epochs=5,
+        data_file=f"{os.path.dirname(os.path.abspath(__file__))}/words_data.yaml",
+        model_path="yolov8n.pt"
+    )
+    """
 
     # Uncomment the line below to test model on detecting words
-    # inference("../images", WORD_DETECT_BEST_MODEL, min_confidence=0.3)
+    #inference("../images", WORD_DETECT_BEST_MODEL, min_confidence=0.3)
 
     # Uncomment the line below to test model on detecting lines
     # inference("../datasets/lines-obb/valid/images", LINES_OBB_BEST, min_confidence=0.1, show=True)
+    
     ...

--- a/src/word_detection.py
+++ b/src/word_detection.py
@@ -22,7 +22,7 @@ LINES_OBB_BEST = os.path.join("models", "lines_obb_best.pt")
 def fixup_yaml(yaml_path: str) -> None:
     """Fix the absolute path to datasets in a yaml configuration"""
     if not os.path.exists(yaml_path):
-        print(f"ERROR: Can not fixup'{yaml_path}', REASON: Does not exist")
+        print(f"ERROR: Can not fixup '{yaml_path}', REASON: Does not exist")
         return
 
     with open(yaml_path, 'r') as file:


### PR DESCRIPTION
@Zarathustra4 solves #15, now updates relative path inside of yaml on each new train run.
Awaiting your review on [this one](https://github.com/AIVMZB/Latina/blob/e9f5d0e4d202e87e09b149d1f2ff263b168236cb/src/word_detection.py#L22), also edited the overall look of the code if you don't mind.

Now looks for datasets folder inside of a project directory (same level as src/) and for a corresponding folder name that must be equal to the .yaml configuration file name. Basically if we have lines_obb.yaml we should go ahead and create 'datasets/lines_obb/' folder with all required content based on the configuration body itself.